### PR TITLE
fix: indentation for continue statement in _main

### DIFF
--- a/src/ebd_toolchain/main.py
+++ b/src/ebd_toolchain/main.py
@@ -167,7 +167,7 @@ def _main(input_path: Path, output_path: Path, export_types: list[Literal["puml"
                 json_path = output_path / Path(f"{ebd_key}.json")
                 _dump_json(json_path, ebd_meta_data)
                 click.secho(f"💾 Successfully exported '{ebd_key}.json' to {json_path.absolute()}")
-                continue
+            continue
         try:
             assert not isinstance(docx_tables, EbdNoTableSection)
             converter = DocxTableConverter(


### PR DESCRIPTION
truely skips further processing if no EBD table is present