### PR TITLE
Revert "ci: Use GITHUB_TOKEN instead of PAT for GHCR publish workflow (#367)"

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,9 +8,6 @@ jobs:
   push_to_registry:
     name: Push Docker image to GHCR
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
 
     steps:
       - name: Check out the repo
@@ -22,7 +19,9 @@ jobs:
           VERSION=$(echo ${GITHUB_REF#refs/tags/})
           echo "VERSION=$VERSION" >> $GITHUB_ENV
       - name: Log in to GHCR
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+        # the token has repo:(read+write) and package(read+write) scope and expires on 2026-05-15
+        # https://github.com/Hochfrequenz/ebd_toolchain/settings/secrets/actions/GHCR_PUSH_TOKEN
+        run: echo "${{ secrets.GHCR_PUSH_TOKEN }}" | docker login ghcr.io -u hf-kklein --password-stdin
 
       - name: Build and push
         run: |

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,7 +19,7 @@ jobs:
           VERSION=$(echo ${GITHUB_REF#refs/tags/})
           echo "VERSION=$VERSION" >> $GITHUB_ENV
       - name: Log in to GHCR
-        # the token has repo:(read+write) and package(read+write) scope and expires on 2026-05-15
+        # the token has repo:(read+write) and package(read+write) scope and expires on 2027-05-15
         # https://github.com/Hochfrequenz/ebd_toolchain/settings/secrets/actions/GHCR_PUSH_TOKEN
         run: echo "${{ secrets.GHCR_PUSH_TOKEN }}" | docker login ghcr.io -u hf-kklein --password-stdin
 


### PR DESCRIPTION
This reverts commit bf239142f6db67e70a6c329f7d5e7ffb12100004.
I think it's easier to renew the PAT once a year than to get this chain of 3 GitHub Actions with permissions working which we need if we try to fix the broken workflow (see https://github.com/Hochfrequenz/ebd_toolchain/pull/368 ).
