### PR TITLE
docs: remove stale tox references left over from the uv migration

### DIFF
--- a/create_env_file.py
+++ b/create_env_file.py
@@ -1,6 +1,6 @@
 """
-This python script copies the example.env to .env if .env does not already exists.
-This is similar to the bash command `mv example.env .env`.
+This python script copies env.example to .env if .env does not already exist.
+This is similar to the bash command `cp env.example .env`.
 It is run as a workflow step (``uv run python create_env_file.py``) in the unit test and coverage CI workflows.
 """
 

--- a/create_env_file.py
+++ b/create_env_file.py
@@ -1,7 +1,7 @@
 """
 This python script copies the example.env to .env if .env does not already exists.
 This is similar to the bash command `mv example.env .env`.
-It is used in all tox environments except the linting environment.
+It is run as a workflow step (``uv run python create_env_file.py``) in the unit test and coverage CI workflows.
 """
 
 from pathlib import Path


### PR DESCRIPTION
Closes #415

This repo was migrated to uv and no longer has a `tox.ini`, but the module docstring in `create_env_file.py` still claimed the script "is used in all tox environments except the linting environment". This is misleading for the next person (and for agents) reading the code.

The script is actually run as a workflow step (`uv run python create_env_file.py`) in `.github/workflows/unittests.yml` and `.github/workflows/coverage.yml` (the equivalent line in `python-publish.yml` is commented out). The docstring is reworded to describe that.

Doc-only change; no behavior change.

**Deliberately untouched** (per issue #415):
- Historical plan/spec records under `docs/**/plans/**` and `docs/**/specs/**` (a frozen record)
- The `.tox/` line in `.gitignore` (harmless)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
